### PR TITLE
fix query params for End of Day and Intraday requests

### DIFF
--- a/util/formatOptionsStocks.js
+++ b/util/formatOptionsStocks.js
@@ -49,8 +49,8 @@ function formatOptions(options) {
   } = options;
   query += limit !== undefined ? `limit=${limit}&` : '';
   query += symbols !== undefined ? `symbols=${symbols}&` : '';
-  query += exchange !== undefined ? `symbols=${exchange}&` : '';
-  query += sort !== undefined ? `dep_iata=${sort}&` : '';
+  query += exchange !== undefined ? `exchange=${exchange}&` : '';
+  query += sort !== undefined ? `sort=${sort}&` : '';
   query += date_from !== undefined ? `date_from=${date_from}&` : '';
   query += date_to !== undefined ? `date_to=${date_to}&` : '';
   query += offset !== undefined ? `offset=${offset}&` : '';

--- a/util/formatOptionsStocksIntraday.js
+++ b/util/formatOptionsStocksIntraday.js
@@ -52,9 +52,9 @@ function formatOptionsIntraday(options) {
   } = options;
   query += limit !== undefined ? `limit=${limit}&` : '';
   query += symbols !== undefined ? `symbols=${symbols}&` : '';
-  query += exchange !== undefined ? `symbols=${exchange}&` : '';
+  query += exchange !== undefined ? `exchange=${exchange}&` : '';
   query += interval !== undefined ? `interval=${interval}&` : '';
-  query += sort !== undefined ? `dep_iata=${sort}&` : '';
+  query += sort !== undefined ? `sort=${sort}&` : '';
   query += date_from !== undefined ? `date_from=${date_from}&` : '';
   query += date_to !== undefined ? `date_to=${date_to}&` : '';
   query += offset !== undefined ? `offset=${offset}&` : '';


### PR DESCRIPTION
Another fix from me. I don't know what `dep_iata` was supposed to mean but I checked with MarketStack docs and `sort` is the one that they list in the request params.